### PR TITLE
Fix item display and database queries

### DIFF
--- a/TEST KC SHOP/app/database/requests.py
+++ b/TEST KC SHOP/app/database/requests.py
@@ -32,7 +32,7 @@ async def get_items_by_feature(feature_key: str, value: str):
             text(f'SELECT rowid, * FROM items WHERE "{column}" = :val'),
             {"val": value}
         )
-        return result.fetchall()
+        return result.mappings().all()
 
 async def get_item_by_id(item_id: int):
     async with async_session() as session:

--- a/TEST KC SHOP/app/handlers.py
+++ b/TEST KC SHOP/app/handlers.py
@@ -95,8 +95,8 @@ async def item_handler(callback: CallbackQuery):
         return
 
     text = (
-        f"{item['Цена']}\n"
-        f"Цена: {item['Наименование']}\n"
+        f"{item['Наименование']}\n"
+        f"Цена: {item['Цена']}\n"
         f"Код: {item['Код']}\n"
         f"Вид: {item['Вид']}\n"
         f"Пустотность: {item['Пустотность']}\n"

--- a/TEST KC SHOP/app/keyboards.py
+++ b/TEST KC SHOP/app/keyboards.py
@@ -39,8 +39,8 @@ def feature_values(feature, values):
 def feature_items(feature, value, items):
     keyboard = InlineKeyboardBuilder()
     for item in items:
-        rowid = item[0]
-        name = item[1]
+        rowid = item["rowid"]
+        name = item["Наименование"]
         keyboard.row(
             InlineKeyboardButton(
                 text=name,


### PR DESCRIPTION
## Summary
- Correct item detail text
- Map DB query results for keyboard item names

## Testing
- `python -m py_compile 'TEST KC SHOP/run.py' 'TEST KC SHOP/app/handlers.py' 'TEST KC SHOP/app/keyboards.py' 'TEST KC SHOP/app/database/models.py' 'TEST KC SHOP/app/database/requests.py'`
- `TG_TOKEN=dummy python 'TEST KC SHOP/run.py'` *(fails: TokenValidationError)*

------
https://chatgpt.com/codex/tasks/task_b_68902cb6d57c83259fed938398fbfdd4