### PR TITLE
Fix SQLite database path resolution

### DIFF
--- a/TEST KC SHOP/app/database/models.py
+++ b/TEST KC SHOP/app/database/models.py
@@ -1,9 +1,15 @@
 import os
+from pathlib import Path
+
 from sqlalchemy import String, BigInteger, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase
 from sqlalchemy.ext.asyncio import AsyncAttrs, async_sessionmaker, create_async_engine
 
-DB_URL = os.getenv('DB_URL', 'sqlite+aiosqlite:///оригинал.sqlite3')
+# Build absolute path to the default SQLite database so that the bot works
+# regardless of the current working directory.
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+default_db_path = BASE_DIR / "оригинал.sqlite3"
+DB_URL = os.getenv('DB_URL', f"sqlite+aiosqlite:///{default_db_path.as_posix()}")
 engine = create_async_engine(url=DB_URL, echo=True)
 async_session = async_sessionmaker(engine)
 


### PR DESCRIPTION
## Summary
- derive SQLite path relative to project so bot can find `оригинал.sqlite3` regardless of current working directory

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_b_6890364481388325a971f6a66a69cfd4